### PR TITLE
Remove cardNumber isNumeric validation

### DIFF
--- a/src/lib/validations/auth/paymentSchema.ts
+++ b/src/lib/validations/auth/paymentSchema.ts
@@ -4,7 +4,7 @@ import * as z from "zod";
 export const paymentSchema = z
   .object({
     name: z.string(),
-    cardNumber: z.string().refine(validator.isNumeric, "Invalid card number"),
+    cardNumber: z.string(),
     expMonth: z.enum([
       ...(Array.from({ length: 12 }, (_, i) =>
         (i + 1).toString().padStart(2, "0")


### PR DESCRIPTION
This pull request removes the isNumeric validation for the cardNumber field in the payment schema. The validation was unnecessary for this demo app.