### PR TITLE
Add Signup button on mobile Navbar

### DIFF
--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -101,7 +101,7 @@ const Navbar = () => {
     <nav className="sticky top-0 shrink-0 w-full h-16 bg-background/75 backdrop-blur-md border-b z-40">
       <div className="x-padding h-full flex items-center gap-8">
         {logo}
-        <div className="flex-1 flex justify-end items-center gap-4">
+        <div className="flex-1 flex justify-end items-center gap-2 lg:gap-4">
           {user ? (
             <Button
               variant="outline"
@@ -119,7 +119,7 @@ const Navbar = () => {
               <NavLink link={navLinks.login} />
               <Link
                 href="/auth/signup"
-                className={cn(buttonVariants(), "hidden lg:inline-flex")}
+                className={buttonVariants({ size: "sm" })}
               >
                 <UserPlus2Icon size={16} />
                 Sign up


### PR DESCRIPTION
This pull request adds a "Signup" button to the mobile navigation bar. The button is displayed on the right side of the navigation bar and allows users to sign up for an account.